### PR TITLE
Add documentation for Datadog EU intake URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ The `datadog-connector` module provisions a Kinesis Firehose which is configured
 
 To provide the Sym Runtime with access to the resources created in this `Connector`, use the `aws/kinesis-firehose` addon in the `runtime-connector` module.
 
+For EU Datadog, make sure to set the `datadog_intake_url` input to `https://aws-kinesis-http-intake.logs.datadoghq.eu/v1/input`!
+
 SECURITY NOTE: The `datadog_access_key` variable is [sensitive](https://learn.hashicorp.com/tutorials/terraform/sensitive-variables). Be sure to manage this value in an environment variable or a `tfvars` file that is excluded from version control. For example, `export TF_VAR_datadog_access_key="my-access-key"`.
 
 ```hcl

--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,7 @@ variable "tags" {
 }
 
 variable "datadog_intake_url" {
-  description = "Intake url for Datadog to consume Kinesis Firehose messages"
+  description = "Intake url for Datadog to consume Kinesis Firehose messages. For EU Datadog, set to 'https://aws-kinesis-http-intake.logs.datadoghq.eu/v1/input'."
   type        = string
   default     = "https://aws-kinesis-http-intake.logs.datadoghq.com/v1/input"
 }


### PR DESCRIPTION
# Summary
- For EU Datadog, the intake URL is different. This PR adds documentation to indicate which input variable to set.