### PR TITLE
Bump kinesis_firehose_connector module to version 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.tfvars
 *.terraform.lock.hcl
 .terraform/
+terraform.tfstate*

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ SECURITY NOTE: The `datadog_access_key` variable is [sensitive](https://learn.ha
 ```hcl
 module "datadog_connector" {
   source  = "symopsio/datadog-connector/sym"
-  version = ">= 1.0.0"
+  version = ">= 2.0.0"
 
   environment = "sandbox"
   datadog_access_key = var.sensitive_access_key

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ locals {
 
 module "kinesis_firehose_connector" {
   source = "symopsio/kinesis-firehose-connector/sym"
-  version = ">= 1.0.0, < 2.0.0"
+  version = ">= 3.0.0, < 4.0.0"
 
   environment = var.environment
   name_prefix = var.name_prefix


### PR DESCRIPTION
# Summary
Bumps the `kinesis_firehose_connector` version to ensure that backup S3 buckets generated have unique names
