### PR TITLE
Support Terraform Provider 4.x

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "kinesis_firehose_connector" {
-  source = "symopsio/kinesis-firehose-connector/sym"
+  source = "symopsio/kinesis-firehose-connector/aws"
   version = ">= 3.0.0, < 4.0.0"
 
   environment = var.environment

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = ">= 3.0"
     }
   }
 }


### PR DESCRIPTION
Changes the AWS provider requirement to >= 3.0 and uptakes the new `symopsio/kinesis-firehose-connector/aws` module