### PR TITLE
[SYM-3644] Support AWS Provider 5.x

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Auto-request the eng team for all opened PRs
+*       @symopsio/eng

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ locals {
 
 module "kinesis_firehose_connector" {
   source  = "symopsio/kinesis-firehose-connector/aws"
-  version = ">= 3.0.0, < 4.0.0"
+  version = ">= 4.0.0, < 5.0.0"
 
   environment = var.environment
   name_prefix = var.name_prefix

--- a/main.tf
+++ b/main.tf
@@ -15,11 +15,6 @@ resource "aws_kinesis_firehose_delivery_stream" "this" {
   name        = "${var.name_prefix}SymDatadogFirehose${title(var.environment)}"
   destination = "http_endpoint"
 
-  s3_configuration {
-    role_arn   = module.kinesis_firehose_connector.firehose_role_arn
-    bucket_arn = module.kinesis_firehose_connector.firehose_bucket_arn
-  }
-
   http_endpoint_configuration {
     url                = var.datadog_intake_url
     name               = "Datadog"
@@ -28,6 +23,11 @@ resource "aws_kinesis_firehose_delivery_stream" "this" {
     retry_duration     = var.retry_duration
     buffering_size     = var.buffering_size
     buffering_interval = var.buffering_interval
+
+    s3_configuration {
+      role_arn   = module.kinesis_firehose_connector.firehose_role_arn
+      bucket_arn = module.kinesis_firehose_connector.firehose_bucket_arn
+    }
 
     request_configuration {
       content_encoding = "GZIP"


### PR DESCRIPTION
# Summary
- Bumps the `kinesis_firehose_connector` submodule constraints to pull in the new major version, which supports AWS Provider 5.x
- Adds the eng team to `CODEOWNERS` to auto-request review on opened PRs
