### PR TITLE
[SYM-4855] Address AWS Provider 4.x S3 bucket deprecation warnings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Auto-request the eng team for all opened PRs
+*       @symopsio/eng

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ locals {
 
 module "kinesis_firehose_connector" {
   source  = "symopsio/kinesis-firehose-connector/aws"
-  version = ">= 3.0.0, < 4.0.0"
+  version = ">= 4.0.0, < 5.0.0"
 
   environment = var.environment
   name_prefix = var.name_prefix

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 4.9.0, < 5.0.0"
     }
   }
 }


### PR DESCRIPTION
# Summary
- Adds `symopsio/eng` as a codeowner
- Bumps the `kinesis-firehose-connector` module to `v4.0.0`, which removes the deprecation warnings
- Pins the AWS Provider to `>= 4.9.0` to match the `kinesis-firehose-connector`
- Pins the AWS Provider to `< 5.0.0`, because AWS Provider 5.x introduces breaking changes to the `kinesis_firehose_delivery_stream` resource


**This PR will be released as a major version `v3.0.0`, because it removes support for AWS Provider 3.x**

# Testing
- Applied the module with the configuration on `main`, then applied these changes with `terraform init && terraform apply`.
  - Verified that the updated configuration applies cleanly
