### PR TITLE
[SYM-4856] Support AWS Provider 5.x

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,11 +15,6 @@ resource "aws_kinesis_firehose_delivery_stream" "this" {
   name        = "${var.name_prefix}SymDatadogFirehose${title(var.environment)}"
   destination = "http_endpoint"
 
-  s3_configuration {
-    role_arn   = module.kinesis_firehose_connector.firehose_role_arn
-    bucket_arn = module.kinesis_firehose_connector.firehose_bucket_arn
-  }
-
   http_endpoint_configuration {
     url                = var.datadog_intake_url
     name               = "Datadog"
@@ -28,6 +23,11 @@ resource "aws_kinesis_firehose_delivery_stream" "this" {
     retry_duration     = var.retry_duration
     buffering_size     = var.buffering_size
     buffering_interval = var.buffering_interval
+
+    s3_configuration {
+      role_arn   = module.kinesis_firehose_connector.firehose_role_arn
+      bucket_arn = module.kinesis_firehose_connector.firehose_bucket_arn
+    }
 
     request_configuration {
       content_encoding = "GZIP"

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0, < 5.0.0"
+      version = ">= 5.0.0"
     }
   }
 }


### PR DESCRIPTION
# Summary
- Updates the `aws_kinesis_firehose_delivery_stream` resource according to the [AWS Provider 5.x Upgrade Guide](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-5-upgrade#resourceaws_kinesis_firehose_delivery_stream)
- Pins the AWS Provider version to `>= 5.0.0`, as these changes are not compatible with previous provider versions

**Note: This PR will be released as a major version `v4.0.0`, because it introduces breaking changes incompatible with AWS Provider < 5.0.0**

# Testing
- Applied the configuration from https://github.com/symopsio/terraform-aws-datadog-connector/pull/5
- Ran `terraform init -upgrade && terraform apply`, verified that AWS Provider 5.x was pulled, and verified that the update applies cleanly (no changes required)


![Screenshot 2023-06-05 at 11 19 21 AM](https://github.com/symopsio/terraform-aws-datadog-connector/assets/10479740/8a5bf810-2eb8-4c97-9096-fe71b7202da3)

![Screenshot 2023-06-05 at 11 18 54 AM](https://github.com/symopsio/terraform-aws-datadog-connector/assets/10479740/76b936c7-f0ea-4633-882d-c641f95a9c88)
